### PR TITLE
DSDEGP-1421 First pass at pullapprove config.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,45 @@
+version: 2
+
+group_defaults:
+  always_pending:
+    labels:
+      - do-not-merge
+      - needs-rebase
+      - work-in-progress
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^:+1:'
+  author_approval:
+    ignored: true
+
+groups:
+  develop-reviewers:
+    required: 1
+    teams:
+      - dsde-pipelines-developers
+    conditions:
+      branches:
+        - develop
+
+  staging-reviewers:
+    required: 2
+    teams:
+      -dsde-pipelines-developers
+    conditions:
+      branches:
+        - staging
+    reset_on_push:
+      enabled: true
+
+  prod-reviewers:
+    required: 2
+    # Based on the description of DSDEGP-1420, changes to prod should
+    # only be allowed with the approval of both Jay and KT.
+    users:
+      - jacarey
+      - ktibbett
+    conditions:
+      branches:
+        - master
+    reset_on_push:
+      enabled: true


### PR DESCRIPTION
### Description

This isn't as intense as the [gotc](https://github.com/broadinstitute/gotc/blob/develop/.pullapprove.yml) configuration, but it's a bit more fleshed out than the [dsde-pipelines ](https://github.com/broadinstitute/dsde-pipelines/blob/develop/.pullapprove.yml) version based off our discussions / open tickets on how to handle changes to staging and production.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
