### PR TITLE
Fix timeout override in WgsUbamWebServiceSpec (take two)

### DIFF
--- a/clio-server/src/test/resources/application.conf
+++ b/clio-server/src/test/resources/application.conf
@@ -5,3 +5,10 @@ clio.server {
     replicate-indices: false
   }
 }
+
+akka {
+  test {
+    # Scale default timeouts by 3 to avoid intermittent errors in Jenkins
+    timefactor = 3.0
+  }
+}

--- a/clio-server/src/test/scala/org/broadinstitute/clio/server/webservice/WgsUbamWebServiceSpec.scala
+++ b/clio-server/src/test/scala/org/broadinstitute/clio/server/webservice/WgsUbamWebServiceSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.clio.server.webservice
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json
 import org.broadinstitute.clio.server.MockClioApp
@@ -12,8 +12,6 @@ import org.broadinstitute.clio.util.json.JsonSchemas
 import org.broadinstitute.clio.util.model.DocumentStatus
 
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.concurrent.duration._
 
 class WgsUbamWebServiceSpec
     extends FlatSpec
@@ -178,7 +176,6 @@ class WgsUbamWebServiceSpec
   }
 
   it should "return a JSON schema" in {
-    implicit val timeout: RouteTestTimeout = RouteTestTimeout(3.seconds)
     val webService = new MockWgsUbamWebService()
     Get("/schema") ~> webService.getSchema ~> check {
       responseAs[Json] should be(JsonSchemas.WgsUbam)

--- a/clio-server/src/test/scala/org/broadinstitute/clio/server/webservice/WgsUbamWebServiceSpec.scala
+++ b/clio-server/src/test/scala/org/broadinstitute/clio/server/webservice/WgsUbamWebServiceSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.clio.server.webservice
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json
 import org.broadinstitute.clio.server.MockClioApp
@@ -10,6 +10,7 @@ import org.broadinstitute.clio.server.dataaccess.MemoryWgsUbamSearchDAO
 import org.broadinstitute.clio.server.webservice.WebServiceAutoDerivation._
 import org.broadinstitute.clio.util.json.JsonSchemas
 import org.broadinstitute.clio.util.model.DocumentStatus
+
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
@@ -177,9 +178,9 @@ class WgsUbamWebServiceSpec
   }
 
   it should "return a JSON schema" in {
+    implicit val timeout: RouteTestTimeout = RouteTestTimeout(3.seconds)
     val webService = new MockWgsUbamWebService()
     Get("/schema") ~> webService.getSchema ~> check {
-      implicit val timeout: Duration = 3.seconds
       responseAs[Json] should be(JsonSchemas.WgsUbam)
     }
   }


### PR DESCRIPTION
### Description

This test is still intermittently failing on Jenkins even with the new implicit timeout, so I dug into it some more and found I was introducing the implicit into the wrong scope / with the wrong type.

Investigation recap:
- The failure we're seeing is coming from [this line](https://github.com/akka/akka-http/blob/40bd7a2d14ecd92eb1527d43a3f56d51e2c17e23/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala#L93) within Akka-HTTP-testkit's `RouteTestResult`
- `RouteTestResult` takes a `FiniteDuration` as an explicit parameter.
- The parameter is set at [this line](https://github.com/akka/akka-http/blob/40bd7a2d14ecd92eb1527d43a3f56d51e2c17e23/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala#L154), pulled from an implicit `RouteTestTimeout` parameter to `injectIntoRoute`
- `injectIntoRoute` outputs an implicit `TildeArrow[RequestContext, Future[RouteResult]]` based on its implicit inputs
- The [`~>` method](https://github.com/akka/akka-http/blob/40bd7a2d14ecd92eb1527d43a3f56d51e2c17e23/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala#L125) takes an implicit `TildeArrow[A, B]`
- So:
  - When we do `Get("/schema") ~> webService.getSchema ~> check`, the `~>` calls will search for an implicit `TildeArrow`
  - Since `injectIntoRoute` is implicit, it'll automatically kick in to produce the required `TildeArrow` instance, pulling its own implicit parameters (including a `RouteTestTimeout`) from the void in the process
  - Putting an implicit `RouteTestTimeout` in the local scope of the `~>` calls will make the implicit calls to `injectIntoRoute` use the larger timeout, avoiding the intermittent 1-second timeout failures

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
