### PR TITLE
DSDEGP-1547: Detect version skew in BasicTests.

### DIFF
--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/BasicTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/BasicTests.scala
@@ -22,12 +22,13 @@ trait BasicTests { self: BaseIntegrationSpec =>
       )
   }
 
-  it should "report a git-hash version at /version" in {
-    clioWebClient.getClioServerVersion
-      .flatMap(Unmarshal(_).to[VersionInfo])
-      .map(
-        _.version should fullyMatch regex """\d+\.\d+\.\d+-g[0-9a-f]{7}-SNAP"""
-      )
+  it should "report the server version of this test at /version" in {
+    for {
+      response <- clioWebClient.getClioServerVersion
+      versionInfo <- Unmarshal(response).to[VersionInfo]
+    } yield {
+      versionInfo.version should be(System.getenv("CLIO_DOCKER_TAG"))
+    }
   }
 
   it should "reject requests to invalid routes" in {


### PR DESCRIPTION
Will this help us avoid debugging version skew between test code and the Clio server?

_Please explain the changes you made here._
_Explain the **motivation** for making this change. What existing problem does the pull request solve?_
_Mention any JIRA issues fixed, addressed or otherwise related to this pull request, including issue numbers or hard links for issues in other repos._

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
