### PR TITLE
PO-10151 Patch in hyphen case for Clio command names.

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/Commands.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/Commands.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.clio.client.commands
 
 import akka.http.scaladsl.model.HttpResponse
+import enumeratum.EnumEntry.Hyphencase
 import enumeratum._
 import org.broadinstitute.clio.client.parser.BaseArgs
 import org.broadinstitute.clio.client.webclient.ClioWebClient
@@ -8,7 +9,7 @@ import org.broadinstitute.clio.client.webclient.ClioWebClient
 import scala.collection.immutable.IndexedSeq
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait CommandType extends EnumEntry
+sealed trait CommandType extends EnumEntry with Hyphencase
 
 object Commands extends Enum[CommandType] {
   override val values: IndexedSeq[CommandType] = findValues

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/parser/BaseArgs.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/parser/BaseArgs.scala
@@ -32,7 +32,7 @@ class BaseParser extends scopt.OptionParser[BaseArgs]("clio-client") {
     .action((token, conf) => conf.copy(bearerToken = Some(token)))
     .text("A valid bearer token for authentication.")
 
-  cmd(Commands.AddWgsUbam.toString)
+  cmd(Commands.AddWgsUbam.entryName)
     .action((_, c) => c.copy(command = Some(Commands.AddWgsUbam)))
     .text("This command is used to add a whole genome unmapped bam.")
     .children(
@@ -67,7 +67,7 @@ class BaseParser extends scopt.OptionParser[BaseArgs]("clio-client") {
         .text("The location for this whole genome unmapped bam. (Required)")
     )
 
-  cmd(Commands.QueryWgsUbam.toString)
+  cmd(Commands.QueryWgsUbam.entryName)
     .action((_, c) => c.copy(command = Some(Commands.QueryWgsUbam)))
     .text("This command is used to query a whole genome unmapped bam.")
     .children(

--- a/clio-client/src/test/scala/org/broadinstitute/client/commands/AddWgsUbamSpec.scala
+++ b/clio-client/src/test/scala/org/broadinstitute/client/commands/AddWgsUbamSpec.scala
@@ -3,7 +3,10 @@ package org.broadinstitute.client.commands
 import io.circe.{DecodingFailure, ParsingFailure}
 import org.broadinstitute.client.BaseClientSpec
 import org.broadinstitute.client.webclient.MockClioWebClient
-import org.broadinstitute.clio.client.commands.{AddWgsUbamCommand, CommandDispatch}
+import org.broadinstitute.clio.client.commands.{
+  AddWgsUbamCommand,
+  CommandDispatch
+}
 import org.broadinstitute.clio.client.parser.BaseArgs
 
 class AddWgsUbamSpec extends BaseClientSpec {
@@ -11,7 +14,7 @@ class AddWgsUbamSpec extends BaseClientSpec {
 
   it should "throw a parsing failure if the metadata is not valid json" in {
 
-    a [ParsingFailure] should be thrownBy {
+    a[ParsingFailure] should be thrownBy {
       val config = BaseArgs(
         flowcell = testFlowcell,
         lane = testLane,
@@ -23,7 +26,8 @@ class AddWgsUbamSpec extends BaseClientSpec {
 
       CommandDispatch.checkResponse(
         AddWgsUbamCommand
-          .execute(MockClioWebClient.returningOk, config))
+          .execute(MockClioWebClient.returningOk, config)
+      )
     }
   }
 
@@ -37,7 +41,9 @@ class AddWgsUbamSpec extends BaseClientSpec {
         metadataLocation = metadataPlusExtraFieldsFileLocation,
         bearerToken = testBearer
       )
-      CommandDispatch.checkResponse(AddWgsUbamCommand.execute(MockClioWebClient.returningOk, config))
+      CommandDispatch.checkResponse(
+        AddWgsUbamCommand.execute(MockClioWebClient.returningOk, config)
+      )
     }
   }
 
@@ -50,9 +56,10 @@ class AddWgsUbamSpec extends BaseClientSpec {
       metadataLocation = metadataFileLocation,
       bearerToken = testBearer
     )
-    CommandDispatch.checkResponse(AddWgsUbamCommand.execute(MockClioWebClient.returningInternalError, config)) should be(
-      false
-    )
+    CommandDispatch.checkResponse(
+      AddWgsUbamCommand
+        .execute(MockClioWebClient.returningInternalError, config)
+    ) should be(false)
   }
 
   it should "return true if the server response is OK" in {
@@ -64,7 +71,9 @@ class AddWgsUbamSpec extends BaseClientSpec {
       metadataLocation = metadataFileLocation,
       bearerToken = testBearer
     )
-    CommandDispatch.checkResponse(AddWgsUbamCommand.execute(MockClioWebClient.returningOk, config)) should be(true)
+    CommandDispatch.checkResponse(
+      AddWgsUbamCommand.execute(MockClioWebClient.returningOk, config)
+    ) should be(true)
   }
 
 }

--- a/clio-client/src/test/scala/org/broadinstitute/client/util/TestData.scala
+++ b/clio-client/src/test/scala/org/broadinstitute/client/util/TestData.scala
@@ -8,7 +8,9 @@ import org.broadinstitute.clio.util.model.DocumentStatus
 
 trait TestData {
 
-  val metadataFileLocation = Some("clio-client/src/test/resources/testdata/metadata")
+  val metadataFileLocation = Some(
+    "clio-client/src/test/resources/testdata/metadata"
+  )
   val badMetadataFileLocation =
     Some("clio-client/src/test/resources/testdata/badmetadata")
   val metadataPlusExtraFieldsFileLocation =
@@ -32,7 +34,7 @@ trait TestData {
 
   //missing lane
   val missingRequired = Array(
-    Commands.AddWgsUbam.toString,
+    Commands.AddWgsUbam.entryName,
     "-m",
     metadataFileLocation.get,
     "-f",
@@ -45,7 +47,7 @@ trait TestData {
 
   //missing lane
   val missingOptional = Array(
-    Commands.QueryWgsUbam.toString,
+    Commands.QueryWgsUbam.entryName,
     "-f",
     testFlowcell.get,
     "-n",
@@ -55,7 +57,7 @@ trait TestData {
   )
 
   val goodAddCommand = Array(
-    Commands.AddWgsUbam.toString,
+    Commands.AddWgsUbam.entryName,
     "-m",
     metadataFileLocation.get,
     "-f",


### PR DESCRIPTION
### Description

Clio in dev uses hypen-case for its command names, and that's what Trevyn built Zamboni against. Prod clio is so far behind that it's still using PascalCase for commands. This patches the prod client to use hyphen-case so we don't have to flip-flop zamboni.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
