### PR TITLE
Only print warning about missing artifactory creds once.

### DIFF
--- a/project/src/main/scala/org/broadinstitute/clio/publish/ArtifactoryPublishingPlugin.scala
+++ b/project/src/main/scala/org/broadinstitute/clio/publish/ArtifactoryPublishingPlugin.scala
@@ -20,11 +20,8 @@ object ArtifactoryPublishingPlugin extends AutoPlugin {
   private val artifactoryUsernameVar = "ARTIFACTORY_USERNAME"
   private val artifactoryPasswordVar = "ARTIFACTORY_PASSWORD"
 
-  private lazy val artifactoryCredentials
-    : Def.Initialize[Task[Option[Credentials]]] =
-    Def.task {
-      val log = streams.value.log
-
+  private lazy val artifactoryCredentials: Def.Initialize[Option[Credentials]] =
+    Def.setting {
       val cred = for {
         username <- sys.env.get(artifactoryUsernameVar)
         password <- sys.env.get(artifactoryPasswordVar)
@@ -33,8 +30,9 @@ object ArtifactoryPublishingPlugin extends AutoPlugin {
       }
 
       cred.orElse {
-        log.warn(
-          s"$artifactoryUsernameVar or $artifactoryPasswordVar not set, publishing will fail!"
+        // SBT's logging comes from a task, and tasks can't be used inside settings, so we have to roll our own warning...
+        println(
+          s"[${scala.Console.YELLOW}warn${scala.Console.RESET}] $artifactoryUsernameVar or $artifactoryPasswordVar not set, publishing will fail!"
         )
         None
       }


### PR DESCRIPTION
### Description

It's annoying that a warning about missing artifactory credentials prints on every SBT command we run, even when the command has nothing to do with publishing. The fix isn't pretty because of how SBT's logging infrastructure is set up, but it works...

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
