### PR TITLE
DSDEGP-1782 Stop setting a default regulatory_designation.

### DIFF
--- a/clio-server/src/main/scala/org/broadinstitute/clio/server/service/GvcfService.scala
+++ b/clio-server/src/main/scala/org/broadinstitute/clio/server/service/GvcfService.scala
@@ -12,11 +12,7 @@ import org.broadinstitute.clio.transfer.model.gvcf.{
   TransferGvcfV1QueryInput,
   TransferGvcfV1QueryOutput
 }
-import org.broadinstitute.clio.util.model.{
-  DocumentStatus,
-  RegulatoryDesignation,
-  UpsertId
-}
+import org.broadinstitute.clio.util.model.{DocumentStatus, UpsertId}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -37,10 +33,7 @@ class GvcfService(
   ): Future[UpsertId] = {
     val updatedTransferMetadata = transferMetadata.copy(
       documentStatus =
-        transferMetadata.documentStatus.orElse(Some(DocumentStatus.Normal)),
-      regulatoryDesignation = transferMetadata.regulatoryDesignation.orElse(
-        Some(RegulatoryDesignation.ResearchOnly)
-      )
+        transferMetadata.documentStatus.orElse(Some(DocumentStatus.Normal))
     )
 
     persistenceService

--- a/clio-server/src/main/scala/org/broadinstitute/clio/server/service/WgsCramService.scala
+++ b/clio-server/src/main/scala/org/broadinstitute/clio/server/service/WgsCramService.scala
@@ -12,11 +12,7 @@ import org.broadinstitute.clio.transfer.model.wgscram.{
   TransferWgsCramV1QueryInput,
   TransferWgsCramV1QueryOutput
 }
-import org.broadinstitute.clio.util.model.{
-  DocumentStatus,
-  RegulatoryDesignation,
-  UpsertId
-}
+import org.broadinstitute.clio.util.model.{DocumentStatus, UpsertId}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -37,10 +33,7 @@ class WgsCramService(
   ): Future[UpsertId] = {
     val updatedTransferMetadata = transferMetadata.copy(
       documentStatus =
-        transferMetadata.documentStatus.orElse(Some(DocumentStatus.Normal)),
-      regulatoryDesignation = transferMetadata.regulatoryDesignation.orElse(
-        Some(RegulatoryDesignation.ResearchOnly)
-      )
+        transferMetadata.documentStatus.orElse(Some(DocumentStatus.Normal))
     )
 
     persistenceService

--- a/clio-server/src/test/scala/org/broadinstitute/clio/server/service/GvcfServiceSpec.scala
+++ b/clio-server/src/test/scala/org/broadinstitute/clio/server/service/GvcfServiceSpec.scala
@@ -14,11 +14,7 @@ import org.broadinstitute.clio.transfer.model.gvcf.{
   TransferGvcfV1Metadata,
   TransferGvcfV1QueryInput
 }
-import org.broadinstitute.clio.util.model.{
-  DocumentStatus,
-  Location,
-  RegulatoryDesignation
-}
+import org.broadinstitute.clio.util.model.{DocumentStatus, Location}
 
 class GvcfServiceSpec extends TestKitSuite("GvcfServiceSpec") {
   behavior of "GvcfService"
@@ -84,8 +80,7 @@ class GvcfServiceSpec extends TestKitSuite("GvcfServiceSpec") {
       TransferGvcfV1Metadata(
         gvcfPath = Option(URI.create("gs://path/gvcfPath.gvcf")),
         notes = Option("notable update"),
-        documentStatus = documentStatus,
-        regulatoryDesignation = Some(RegulatoryDesignation.ResearchOnly)
+        documentStatus = documentStatus
       )
     for {
       returnedUpsertId <- gvcfService.upsertMetadata(

--- a/clio-server/src/test/scala/org/broadinstitute/clio/server/service/WgsCramServiceSpec.scala
+++ b/clio-server/src/test/scala/org/broadinstitute/clio/server/service/WgsCramServiceSpec.scala
@@ -14,11 +14,7 @@ import org.broadinstitute.clio.transfer.model.wgscram.{
   TransferWgsCramV1Metadata,
   TransferWgsCramV1QueryInput
 }
-import org.broadinstitute.clio.util.model.{
-  DocumentStatus,
-  Location,
-  RegulatoryDesignation
-}
+import org.broadinstitute.clio.util.model.{DocumentStatus, Location}
 
 class WgsCramServiceSpec extends TestKitSuite("WgsCramServiceSpec") {
   behavior of "WgsCramService"
@@ -95,10 +91,7 @@ class WgsCramServiceSpec extends TestKitSuite("WgsCramServiceSpec") {
       val expectedDocument = WgsCramService.v1DocumentConverter
         .withMetadata(
           WgsCramService.v1DocumentConverter.empty(transferKey),
-          transferMetadata.copy(
-            documentStatus = expectedDocumentStatus,
-            regulatoryDesignation = Some(RegulatoryDesignation.ResearchOnly)
-          )
+          transferMetadata.copy(documentStatus = expectedDocumentStatus)
         )
         .copy(upsertId = returnedUpsertId)
 


### PR DESCRIPTION
### Description

In Phase 2, we set up a default value for regulatoryDesignation to avoid extra backfill work later. The default is applied on every upsert if there's no "regulatory_designation" key in the JSON blob. Setting a default on every cram / gvcf upsert is dangerous, as it'll overwrite any regulatory designation that was set in a previous upsert.

A concrete example of this problem is data delivery. The last step of the deliver-wgs-cram CLP is to upsert:
```
{ "workspace_name": "Some workspace name" }
```
When this upsert comes into the server, the server will look for the regulatory_designation field in the JSON blob. Since it's missing, the server will change the blob to the following:
```
{ "workspace_name": "Some workspace name", "regulatory_designation": "RESEARCH_ONLY" }
```
And then POST that blob into Elasticsearch, overwriting any "regulatory_designation" field that already exists for the cram. It's a happy accident that this isn't also happening for moves and deletes of crams and gvcfs in general.

Now that we're threading regulatory_designation through the Zamboni workflows, we can leave it to the pipeline to handle any default-setting, and remove the logic from Clio.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
