### PR TITLE
DSDEGP-1717: Support adding a prefix to the base name of the cram, crai and md5 during the deliver operation.

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
@@ -50,7 +50,7 @@ sealed abstract class MoveCommand[TI <: TransferIndex](val index: TI)
     extends ClioCommand {
   def key: index.KeyType
   def destination: URI
-  def newPrefix: Option[String] = None
+  def newSamplePrefix: Option[String] = None
 }
 
 sealed abstract class DeleteCommand[TI <: TransferIndex](val index: TI)
@@ -131,7 +131,7 @@ final case class QueryWgsCram(@Recurse queryInput: TransferWgsCramV1QueryInput,
 @CommandName(ClioCommand.moveWgsCramName)
 final case class MoveWgsCram(@Recurse key: TransferWgsCramV1Key,
                              destination: URI,
-                             override val newPrefix: Option[String])
+                             override val newSamplePrefix: Option[String])
     extends MoveCommand(WgsCramIndex)
 
 @CommandName(ClioCommand.deleteWgsCramName)
@@ -142,7 +142,7 @@ final case class DeleteWgsCram(@Recurse key: TransferWgsCramV1Key, note: String)
 final case class DeliverWgsCram(@Recurse key: TransferWgsCramV1Key,
                                 workspaceName: String,
                                 workspacePath: URI,
-                                newPrefix: Option[String])
+                                newSamplePrefix: Option[String])
     extends ClioCommand
 
 object ClioCommand extends ClioParsers {

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
@@ -50,7 +50,6 @@ sealed abstract class MoveCommand[TI <: TransferIndex](val index: TI)
     extends ClioCommand {
   def key: index.KeyType
   def destination: URI
-  def newSamplePrefix: Option[String] = None
 }
 
 sealed abstract class DeleteCommand[TI <: TransferIndex](val index: TI)
@@ -129,11 +128,9 @@ final case class QueryWgsCram(@Recurse queryInput: TransferWgsCramV1QueryInput,
     extends QueryCommand(WgsCramIndex)
 
 @CommandName(ClioCommand.moveWgsCramName)
-final case class MoveWgsCram(
-  @Recurse key: TransferWgsCramV1Key,
-  destination: URI,
-  override val newSamplePrefix: Option[String] = None
-) extends MoveCommand(WgsCramIndex)
+final case class MoveWgsCram(@Recurse key: TransferWgsCramV1Key,
+                             destination: URI)
+    extends MoveCommand(WgsCramIndex)
 
 @CommandName(ClioCommand.deleteWgsCramName)
 final case class DeleteWgsCram(@Recurse key: TransferWgsCramV1Key, note: String)
@@ -143,7 +140,7 @@ final case class DeleteWgsCram(@Recurse key: TransferWgsCramV1Key, note: String)
 final case class DeliverWgsCram(@Recurse key: TransferWgsCramV1Key,
                                 workspaceName: String,
                                 workspacePath: URI,
-                                newSamplePrefix: Option[String])
+                                samplePrefix: Option[String])
     extends ClioCommand
 
 object ClioCommand extends ClioParsers {

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
@@ -129,10 +129,11 @@ final case class QueryWgsCram(@Recurse queryInput: TransferWgsCramV1QueryInput,
     extends QueryCommand(WgsCramIndex)
 
 @CommandName(ClioCommand.moveWgsCramName)
-final case class MoveWgsCram(@Recurse key: TransferWgsCramV1Key,
-                             destination: URI,
-                             override val newSamplePrefix: Option[String])
-    extends MoveCommand(WgsCramIndex)
+final case class MoveWgsCram(
+  @Recurse key: TransferWgsCramV1Key,
+  destination: URI,
+  override val newSamplePrefix: Option[String] = None
+) extends MoveCommand(WgsCramIndex)
 
 @CommandName(ClioCommand.deleteWgsCramName)
 final case class DeleteWgsCram(@Recurse key: TransferWgsCramV1Key, note: String)

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
@@ -50,6 +50,7 @@ sealed abstract class MoveCommand[TI <: TransferIndex](val index: TI)
     extends ClioCommand {
   def key: index.KeyType
   def destination: URI
+  def newPrefix: Option[String] = None
 }
 
 sealed abstract class DeleteCommand[TI <: TransferIndex](val index: TI)
@@ -129,7 +130,8 @@ final case class QueryWgsCram(@Recurse queryInput: TransferWgsCramV1QueryInput,
 
 @CommandName(ClioCommand.moveWgsCramName)
 final case class MoveWgsCram(@Recurse key: TransferWgsCramV1Key,
-                             destination: URI)
+                             destination: URI,
+                             override val newPrefix: Option[String])
     extends MoveCommand(WgsCramIndex)
 
 @CommandName(ClioCommand.deleteWgsCramName)
@@ -139,7 +141,8 @@ final case class DeleteWgsCram(@Recurse key: TransferWgsCramV1Key, note: String)
 @CommandName(ClioCommand.deliverWgsCramName)
 final case class DeliverWgsCram(@Recurse key: TransferWgsCramV1Key,
                                 workspaceName: String,
-                                workspacePath: URI)
+                                workspacePath: URI,
+                                newPrefix: Option[String])
     extends ClioCommand
 
 object ClioCommand extends ClioParsers {

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
@@ -31,7 +31,7 @@ class DeliverWgsCramExecutor(deliverCommand: DeliverWgsCram)
     MoveWgsCram(
       deliverCommand.key,
       deliverCommand.workspacePath,
-      deliverCommand.newPrefix
+      deliverCommand.newSamplePrefix
     )
   import moveCommand.index.implicits._
 

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
@@ -28,7 +28,11 @@ class DeliverWgsCramExecutor(deliverCommand: DeliverWgsCram)
     extends Executor[UpsertId] {
 
   val moveCommand =
-    MoveWgsCram(deliverCommand.key, deliverCommand.workspacePath)
+    MoveWgsCram(
+      deliverCommand.key,
+      deliverCommand.workspacePath,
+      deliverCommand.newPrefix
+    )
   import moveCommand.index.implicits._
 
   override def execute(webClient: ClioWebClient, ioUtil: IoUtil)(

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
@@ -40,7 +40,7 @@ class DeliverWgsCramExecutor(deliverCommand: DeliverWgsCram)
       _ <- writeCramMd5(webClient, ioUtil)
         .logErrorMsg("Failed to write cram md5 to file")
       upsertId <- recordWorkspaceName(webClient)
-        .logErrorMsg("Failed to records workspace name in cram metadata")
+        .logErrorMsg("Failed to record workspace name in cram metadata")
     } yield {
       upsertId
     }

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
@@ -28,11 +28,7 @@ class DeliverWgsCramExecutor(deliverCommand: DeliverWgsCram)
     extends Executor[UpsertId] {
 
   val moveCommand =
-    MoveWgsCram(
-      deliverCommand.key,
-      deliverCommand.workspacePath,
-      deliverCommand.newSamplePrefix
-    )
+    MoveWgsCram(deliverCommand.key, deliverCommand.workspacePath)
   import moveCommand.index.implicits._
 
   override def execute(webClient: ClioWebClient, ioUtil: IoUtil)(
@@ -53,7 +49,8 @@ class DeliverWgsCramExecutor(deliverCommand: DeliverWgsCram)
   private def ensureMove(webClient: ClioWebClient, ioUtil: IoUtil)(
     implicit ec: ExecutionContext
   ): Future[UpsertId] = {
-    val moveExecutor = new MoveExecutor(moveCommand)
+    val moveExecutor =
+      new MoveExecutor(moveCommand, deliverCommand.samplePrefix)
     moveExecutor.execute(webClient, ioUtil).map {
       _.getOrElse {
         throw new IllegalStateException(

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/MoveExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/MoveExecutor.scala
@@ -16,7 +16,8 @@ import org.broadinstitute.clio.util.model.{Location, UpsertId}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI])
+class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI],
+                                        samplePrefix: Option[String] = None)
     extends Executor[Option[UpsertId]] {
 
   import moveCommand.index.implicits._
@@ -24,10 +25,6 @@ class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI])
   private[dispatch] val name: String = moveCommand.index.name
   private[dispatch] val prettyKey = ClassUtil.formatFields(moveCommand.key)
   private val destination: URI = moveCommand.destination
-  private val newPrefix = moveCommand.newSamplePrefix match {
-    case Some(prefix) => prefix
-    case None         => ""
-  }
 
   override def execute(webClient: ClioWebClient, ioUtil: IoUtil)(
     implicit ec: ExecutionContext
@@ -125,7 +122,7 @@ class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI])
     existingMetadata: moveCommand.index.MetadataType
   )(implicit ec: ExecutionContext): Future[Option[UpsertId]] = {
 
-    val newMetadata = existingMetadata.moveInto(destination).prefixed(newPrefix)
+    val newMetadata = existingMetadata.moveInto(destination, samplePrefix)
     val preMoveFields = flattenMetadata(existingMetadata)
     val postMoveFields = flattenMetadata(newMetadata)
 

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/MoveExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/MoveExecutor.scala
@@ -24,6 +24,10 @@ class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI])
   private[dispatch] val name: String = moveCommand.index.name
   private[dispatch] val prettyKey = ClassUtil.formatFields(moveCommand.key)
   private val destination: URI = moveCommand.destination
+  private val newPrefix = moveCommand.newPrefix match {
+    case Some(prefix) => prefix
+    case None         => ""
+  }
 
   override def execute(webClient: ClioWebClient, ioUtil: IoUtil)(
     implicit ec: ExecutionContext
@@ -121,7 +125,7 @@ class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI])
     existingMetadata: moveCommand.index.MetadataType
   )(implicit ec: ExecutionContext): Future[Option[UpsertId]] = {
 
-    val newMetadata = existingMetadata.moveInto(destination)
+    val newMetadata = existingMetadata.moveInto(destination).prefixed(newPrefix)
     val preMoveFields = flattenMetadata(existingMetadata)
     val postMoveFields = flattenMetadata(newMetadata)
 

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/MoveExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/MoveExecutor.scala
@@ -24,7 +24,7 @@ class MoveExecutor[TI <: TransferIndex](moveCommand: MoveCommand[TI])
   private[dispatch] val name: String = moveCommand.index.name
   private[dispatch] val prettyKey = ClassUtil.formatFields(moveCommand.key)
   private val destination: URI = moveCommand.destination
-  private val newPrefix = moveCommand.newPrefix match {
+  private val newPrefix = moveCommand.newSamplePrefix match {
     case Some(prefix) => prefix
     case None         => ""
   }

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
@@ -773,7 +773,7 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val craiContents = s"$randomId --- I am a dummy crai --- $randomId"
     val md5Contents = randomId
 
-    val cramName = s"$newPrefix$randomId.cram"
+    val cramName = s"$randomId.cram"
     val craiName = s"$cramName.crai"
     val md5Name = s"$cramName.md5"
 
@@ -783,9 +783,9 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val craiSource = rootSource.resolve(craiName)
 
     val rootDestination = rootSource.getParent.resolve(s"moved/$randomId/")
-    val cramDestination = rootDestination.resolve(cramName)
-    val craiDestination = rootDestination.resolve(craiName)
-    val md5Destination = rootDestination.resolve(md5Name)
+    val cramDestination = rootDestination.resolve(s"$newPrefix$cramName")
+    val craiDestination = rootDestination.resolve(s"$newPrefix$craiName")
+    val md5Destination = rootDestination.resolve(s"$newPrefix$md5Name")
 
     val key = TransferWgsCramV1Key(Location.GCP, project, sample, version)
     val metadata = TransferWgsCramV1Metadata(

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
@@ -767,12 +767,13 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val project = s"project$randomId"
     val sample = s"sample$randomId"
     val version = 3
+    val newPrefix = "new_prefix_"
 
     val cramContents = s"$randomId --- I am a dummy cram --- $randomId"
     val craiContents = s"$randomId --- I am a dummy crai --- $randomId"
     val md5Contents = randomId
 
-    val cramName = s"$randomId.cram"
+    val cramName = s"$newPrefix$randomId.cram"
     val craiName = s"$cramName.crai"
     val md5Name = s"$cramName.md5"
 
@@ -813,7 +814,9 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
         "--workspace-name",
         workspaceName,
         "--workspace-path",
-        rootDestination.toUri.toString
+        rootDestination.toUri.toString,
+        "--new-sample-prefix",
+        newPrefix
       )
       outputs <- runClientGetJsonAs[Seq[TransferWgsCramV1QueryOutput]](
         ClioCommand.queryWgsCramName,
@@ -841,7 +844,7 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
           TransferWgsCramV1QueryOutput(
             location = Location.GCP,
             project = project,
-            sampleAlias = sample,
+            sampleAlias = s"$newPrefix$sample",
             version = version,
             workspaceName = Some(workspaceName),
             cramPath = Some(cramDestination.toUri),

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
@@ -844,7 +844,7 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
           TransferWgsCramV1QueryOutput(
             location = Location.GCP,
             project = project,
-            sampleAlias = s"$newPrefix$sample",
+            sampleAlias = sample,
             version = version,
             workspaceName = Some(workspaceName),
             cramPath = Some(cramDestination.toUri),

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
@@ -767,7 +767,7 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val project = s"project$randomId"
     val sample = s"sample$randomId"
     val version = 3
-    val newPrefix = "new_prefix_"
+    val samplePrefix = "sample_prefix_"
 
     val cramContents = s"$randomId --- I am a dummy cram --- $randomId"
     val craiContents = s"$randomId --- I am a dummy crai --- $randomId"
@@ -783,9 +783,9 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val craiSource = rootSource.resolve(craiName)
 
     val rootDestination = rootSource.getParent.resolve(s"moved/$randomId/")
-    val cramDestination = rootDestination.resolve(s"$newPrefix$cramName")
-    val craiDestination = rootDestination.resolve(s"$newPrefix$craiName")
-    val md5Destination = rootDestination.resolve(s"$newPrefix$md5Name")
+    val cramDestination = rootDestination.resolve(s"$samplePrefix$cramName")
+    val craiDestination = rootDestination.resolve(s"$samplePrefix$craiName")
+    val md5Destination = rootDestination.resolve(s"$samplePrefix$md5Name")
 
     val key = TransferWgsCramV1Key(Location.GCP, project, sample, version)
     val metadata = TransferWgsCramV1Metadata(
@@ -815,8 +815,8 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
         workspaceName,
         "--workspace-path",
         rootDestination.toUri.toString,
-        "--new-sample-prefix",
-        newPrefix
+        "--sample-prefix",
+        samplePrefix
       )
       outputs <- runClientGetJsonAs[Seq[TransferWgsCramV1QueryOutput]](
         ClioCommand.queryWgsCramName,

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/TransferMetadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/TransferMetadata.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.clio.transfer.model
 
+import java.io.File
 import java.net.URI
 
 import org.broadinstitute.clio.util.model.DocumentStatus
@@ -55,7 +56,7 @@ trait TransferMetadata[M <: TransferMetadata[M]] { self: M =>
   /**
     * Return a copy of this with files transformed by applying
     * `pathMapper` and `samplePrefix`.
-    * 
+    *
     * @param samplePrefix added to files derived from sample names
     * @param pathMapper of files from source to destination URI
     * @return new metadata
@@ -68,8 +69,8 @@ trait TransferMetadata[M <: TransferMetadata[M]] { self: M =>
     */
   protected def moveIntoDirectory(source: URI, destination: URI): URI = {
     // TODO: Rewrite this using a Path-based API.
-    val srcPath = source.getPath
-    destination.resolve(srcPath.substring(srcPath.lastIndexOf('/') + 1))
+    val srcName = new File(source.getPath).getName
+    destination.resolve(srcName)
   }
 
   /**

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/TransferMetadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/TransferMetadata.scala
@@ -27,8 +27,8 @@ trait TransferMetadata[M <: TransferMetadata[M]] { self: M =>
   def pathsToDelete: Seq[URI]
 
   /**
-    * Return a copy of this object in which all files in `pathsToMove`
-    * have been moved to the given destination directory.
+    * Return a copy of this object in which all files have been moved
+    * to the given destination directory.
     *
     * Until we move to a Path-based API, `destination` must end with '/'.
     */
@@ -71,4 +71,12 @@ trait TransferMetadata[M <: TransferMetadata[M]] { self: M =>
       case Some(existing) => Some(s"$existing\n$note")
       case None           => Some(note)
     }
+
+  /**
+    * Return a copy of this in which the `URI` vals are prefixed with
+    * `newPrefix` as necessary
+    *
+    * @return new metadata with some field values prefixed.
+    */
+  def prefixed(newPrefix: String): M = { val _ = newPrefix; self }
 }

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/gvcf/TransferGvcfV1Metadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/gvcf/TransferGvcfV1Metadata.scala
@@ -28,6 +28,7 @@ case class TransferGvcfV1Metadata(
     Seq.concat(gvcfPath, gvcfIndexPath)
 
   override def mapMove(
+    samplePrefix: Option[String] = None,
     pathMapper: Option[URI] => Option[URI]
   ): TransferGvcfV1Metadata = {
     this.copy(

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgscram/TransferWgsCramV1Metadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgscram/TransferWgsCramV1Metadata.scala
@@ -75,8 +75,7 @@ case class TransferWgsCramV1Metadata(
   ): TransferWgsCramV1Metadata = {
     val prefixedCram = cramPath.map { cp =>
       val name = new File(cp.getPath).getName
-      val directory = URI.create(cp.toString.dropRight(name.length))
-      directory.resolve(s"${samplePrefix.getOrElse("")}$name")
+      URI.create(s"${samplePrefix.getOrElse("")}$name")
     }
     val prefixedCrai = prefixedCram.map(pc => URI.create(s"${pc}.crai"))
     this.copy(

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgscram/TransferWgsCramV1Metadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgscram/TransferWgsCramV1Metadata.scala
@@ -89,11 +89,12 @@ case class TransferWgsCramV1Metadata(
     )
 
   override def prefixed(newPrefix: String) = {
-    val cramName = cramPath.map(cp => new File(cp.getPath).getName)
-    val cramDir = cramPath.map(cp => cp.resolve("/../"))
-    val prefixedCramPath = cramDir.map(cd => cd.resolve(s"$newPrefix$cramName"))
-    val prefixedCraiPath =
-      prefixedCramPath.map(pcp => URI.create(s"${pcp.toString}.crai"))
-    this.copy(cramPath = prefixedCramPath, craiPath = prefixedCraiPath)
+    val prefixedCram = cramPath.map { cp =>
+      val name = new File(cp.getPath).getName
+      val directory = URI.create(cp.toString.dropRight(name.length))
+      directory.resolve(s"$newPrefix$name")
+    }
+    val prefixedCrai = prefixedCram.map(pc => URI.create(s"${pc}.crai"))
+    this.copy(cramPath = prefixedCram, craiPath = prefixedCrai)
   }
 }

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgscram/TransferWgsCramV1Metadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgscram/TransferWgsCramV1Metadata.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.clio.transfer.model.wgscram
 
+import java.io.File
 import java.net.URI
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -86,4 +87,13 @@ case class TransferWgsCramV1Metadata(
       documentStatus = Some(DocumentStatus.Deleted),
       notes = appendNote(deletionNote)
     )
+
+  override def prefixed(newPrefix: String) = {
+    val cramName = cramPath.map(cp => new File(cp.getPath).getName)
+    val cramDir = cramPath.map(cp => cp.resolve("/../"))
+    val prefixedCramPath = cramDir.map(cd => cd.resolve(s"$newPrefix$cramName"))
+    val prefixedCraiPath =
+      prefixedCramPath.map(pcp => URI.create(s"${pcp.toString}.crai"))
+    this.copy(cramPath = prefixedCramPath, craiPath = prefixedCraiPath)
+  }
 }

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgsubam/TransferWgsUbamV1Metadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/wgsubam/TransferWgsUbamV1Metadata.scala
@@ -45,6 +45,7 @@ case class TransferWgsUbamV1Metadata(
   override def pathsToDelete: Seq[URI] = ubamPath.toSeq
 
   override def mapMove(
+    samplePrefix: Option[String] = None,
     pathMapper: Option[URI] => Option[URI]
   ): TransferWgsUbamV1Metadata = {
     this.copy(ubamPath = pathMapper(ubamPath))

--- a/clio-util/src/main/scala/org/broadinstitute/clio/util/generic/CaseClassTypeConverter.scala
+++ b/clio-util/src/main/scala/org/broadinstitute/clio/util/generic/CaseClassTypeConverter.scala
@@ -34,7 +34,7 @@ object CaseClassTypeConverter {
 
   /**
     * Create an instance of a CaseClassTypeConverter.
-    * 
+    *
     * @param convertVals Function to modify the values extracted from
     *                    the `From` before they are used to initiate
     *                    an instance of `To`.

--- a/clio-util/src/main/scala/org/broadinstitute/clio/util/generic/CaseClassTypeConverter.scala
+++ b/clio-util/src/main/scala/org/broadinstitute/clio/util/generic/CaseClassTypeConverter.scala
@@ -5,8 +5,9 @@ import scala.reflect.ClassTag
 /**
   * Convert from one case class to another.
   *
-  * @param convertVals Function to modify the the extracted from the From before they are used to initiate an instance
-  *                    of To.
+  * @param convertVals Function to modify the values extracted from
+  *                    the `From` before they are used to initiate an
+  *                    instance of `To`.
   * @tparam From The type of the original case class, with a context bound also specifying that an
   *              `implicit ctagFrom: ClassTag[T]` exists.
   *              https://www.scala-lang.org/files/archive/spec/2.12/07-implicits.html#context-bounds-and-view-bounds
@@ -33,9 +34,10 @@ object CaseClassTypeConverter {
 
   /**
     * Create an instance of a CaseClassTypeConverter.
-    *
-    * @param convertVals Function to modify the the extracted from the From before they are used to initiate an instance
-    *                    of To.
+    * 
+    * @param convertVals Function to modify the values extracted from
+    *                    the `From` before they are used to initiate
+    *                    an instance of `To`.
     * @tparam From The type of the original case class, with a context bound also specifying that an
     *              `implicit ctagFrom: ClassTag[T]` exists.
     *              https://www.scala-lang.org/files/archive/spec/2.12/07-implicits.html#context-bounds-and-view-bounds


### PR DESCRIPTION
Add a --new-sample-prefix option to deliver-wgs-cram CLP to add its
value as a prefix to the base name of the .cram, .cram.md5, and
.cram.crai files.

There is now a do-nothing prefixed() method on the TransferMetadata
type class that is overridden for TransferWgsCramV1Metadata to do the
right thing for its files.

It might be nice to hide the --new-sample-prefix option from the move-
CLPs -- at least for now-- but I don't know how to do that.

Also, 13 integration tests started failing when I rebased onto /develop/.
Got me, but /develop/ fails the same way.  Will look into it tomorrow.