### PR TITLE
Tbl dsdegp 1855 rename crams

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/commands/ClioCommand.scala
@@ -149,7 +149,7 @@ final case class DeliverWgsCram(
   @Recurse key: TransferWgsCramV1Key,
   workspaceName: String,
   workspacePath: URI,
-  samplePrefix: Option[String]
+  newBasename: Option[String]
 ) extends ClioCommand
 
 object ClioCommand extends ClioParsers {

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
@@ -33,14 +33,10 @@ class DeliverWgsCramExecutor(deliverCommand: DeliverWgsCram) extends Executor[Up
     implicit ec: ExecutionContext
   ): Future[UpsertId] = {
 
-    val deliveredFileBasename: String =
-      deliverCommand.samplePrefix.fold(deliverCommand.key.sampleAlias) { prefix =>
-        s"$prefix${deliverCommand.key.sampleAlias}"
-      }
     val moveCommand = MoveWgsCram(
       deliverCommand.key,
       deliverCommand.workspacePath,
-      Some(deliveredFileBasename)
+      deliverCommand.newBasename
     )
 
     val moveExecutor = new MoveExecutor(moveCommand)

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverWgsCramExecutor.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.clio.util.model.UpsertId
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * Special-purpose CLP for delivering crams to Firecloud workspaces.
+  * Special-purpose CLP for delivering crams to FireCloud workspaces.
   *
   * Wraps the move CLP with extra IO / upsert logic:
   *

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
@@ -683,12 +683,13 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
   }
 
   it should "move files, generate an md5 file, and record the workspace name when delivering crams" in {
-    val project = s"project$randomId"
-    val sample = s"sample$randomId"
+    val id = randomId
+    val project = s"project$id"
+    val sample = s"sample$id"
     val version = 3
 
-    val cramContents = s"$randomId --- I am a dummy cram --- $randomId"
-    val craiContents = s"$randomId --- I am a dummy crai --- $randomId"
+    val cramContents = s"$id --- I am a dummy cram --- $id"
+    val craiContents = s"$id --- I am a dummy crai --- $id"
     val md5Contents = randomId
 
     val cramName = s"$sample${WgsCramExtensions.CramExtension}"
@@ -702,7 +703,7 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
 
     val prefix = "new_basename_"
     val newBasename = s"$prefix$sample"
-    val rootDestination = rootSource.getParent.resolve(s"moved/$randomId/")
+    val rootDestination = rootSource.getParent.resolve(s"moved/$id/")
     val cramDestination = rootDestination.resolve(s"$prefix$cramName")
     val craiDestination = rootDestination.resolve(s"$prefix$craiName")
     val md5Destination = rootDestination.resolve(s"$prefix$md5Name")
@@ -714,7 +715,7 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
       cramMd5 = Some(Symbol(md5Contents))
     )
 
-    val workspaceName = s"$randomId-TestWorkspace-$randomId"
+    val workspaceName = s"$id-TestWorkspace-$id"
 
     val _ = Seq((cramSource, cramContents), (craiSource, craiContents)).map {
       case (source, contents) => Files.write(source, contents.getBytes)

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/WgsCramTests.scala
@@ -686,7 +686,6 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val project = s"project$randomId"
     val sample = s"sample$randomId"
     val version = 3
-    val samplePrefix = "sample_prefix_"
 
     val cramContents = s"$randomId --- I am a dummy cram --- $randomId"
     val craiContents = s"$randomId --- I am a dummy crai --- $randomId"
@@ -701,10 +700,12 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
     val cramSource = rootSource.resolve(cramName)
     val craiSource = rootSource.resolve(craiName)
 
+    val prefix = "new_basename_"
+    val newBasename = s"$prefix$sample"
     val rootDestination = rootSource.getParent.resolve(s"moved/$randomId/")
-    val cramDestination = rootDestination.resolve(s"$samplePrefix$cramName")
-    val craiDestination = rootDestination.resolve(s"$samplePrefix$craiName")
-    val md5Destination = rootDestination.resolve(s"$samplePrefix$md5Name")
+    val cramDestination = rootDestination.resolve(s"$prefix$cramName")
+    val craiDestination = rootDestination.resolve(s"$prefix$craiName")
+    val md5Destination = rootDestination.resolve(s"$prefix$md5Name")
 
     val key = TransferWgsCramV1Key(Location.GCP, project, sample, version)
     val metadata = TransferWgsCramV1Metadata(
@@ -734,8 +735,8 @@ trait WgsCramTests { self: BaseIntegrationSpec =>
         workspaceName,
         "--workspace-path",
         rootDestination.toUri.toString,
-        "--sample-prefix",
-        samplePrefix
+        "--new-basename",
+        newBasename
       )
       outputs <- runClientGetJsonAs[Seq[TransferWgsCramV1QueryOutput]](
         ClioCommand.queryWgsCramName,


### PR DESCRIPTION
DSDEGP-1855: Modify the Clio data delivery CLP to support renaming

https://broadinstitute.atlassian.net/browse/DSDEGP-1855

Rename samplePrefix to newBasename to parallel move-wgs-ubam
and pass it through to the MoveExecutor.  Update tests. Fuss a bit.

TIL (in sbt): it:testOnly *DockerIntegrationSpec -- -z delivering
to run only the delivering test.