### PR TITLE
DSDEGP-2014 Indices use hardcoded names - underscores to dashes in es names for c…

### DIFF
--- a/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
+++ b/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
@@ -79,12 +79,14 @@ object ElasticsearchIndex extends Elastic4sAutoDerivation {
     )
 
   implicit val Gvcf: ElasticsearchIndex[DocumentGvcf] =
+    // despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS
     new ElasticsearchIndex[DocumentGvcf](
       "gvcf-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
 
   implicit val WgsCram: ElasticsearchIndex[DocumentWgsCram] =
+    // despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS
     new ElasticsearchIndex[DocumentWgsCram](
       "wgs-cram-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords

--- a/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
+++ b/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
@@ -7,8 +7,6 @@ import com.sksamuel.elastic4s.mappings.FieldDefinition
 import com.sksamuel.elastic4s.{HitReader, Indexable}
 import org.broadinstitute.clio.util.generic.FieldMapper
 
-import scala.reflect.{ClassTag, classTag}
-
 /**
   * An index for an Elasticsearch document.
   *
@@ -34,7 +32,7 @@ class ElasticsearchIndex[Document: FieldMapper](
     * addition, but in GCS's filesystem adapter it's the only indication that this
     * should be treated as a directory, not a file.
     */
-  lazy val rootDir: String = indexName.replaceAll("_", "-") + "/"
+  lazy val rootDir: String = indexName + "/"
 
   /**
     * The source-of-truth directory in which updates to this index
@@ -70,41 +68,29 @@ object ElasticsearchIndex extends Elastic4sAutoDerivation {
   lazy val dateTimeFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy/MM/dd")
 
-  /**
-    * Creates an index using shapeless and reflection.
-    *
-    * @param fieldMapper The object defining how the Scala types of the fields in `Document` should be translated
-    *                    into Elasticsearch field types.
-    * @tparam Document The type of the Elasticsearch document, with a context bound also specifying that both an
-    *                  `implicit ctag: ClassTag[Document]` exists, plus an
-    *                  `implicit fieldMapper: FieldMapper[Document]` exists.
-    *                  https://www.scala-lang.org/files/archive/spec/2.12/07-implicits.html#context-bounds-and-view-bounds
-    * @return The index.
-    */
-  private[elasticsearch] def apply[
-    Document <: ClioDocument: ClassTag: FieldMapper: Indexable: HitReader
-  ](fieldMapper: ElasticsearchFieldMapper): ElasticsearchIndex[Document] = {
-    val esName =
-      ElasticsearchUtil
-        .toElasticsearchName(classTag[Document].runtimeClass.getSimpleName)
-        .stripPrefix("document_")
-
-    // We started without a version suffix, so we keep it that way to avoid breaking things.
-    val versionSuffix = if (fieldMapper.value == 1) "" else s"_v${fieldMapper.value}"
-
-    new ElasticsearchIndex[Document](s"$esName$versionSuffix", fieldMapper)
-  }
+  private val wgsUbamEsName = "wgs-ubam"
+  private val gvcfEsName = "gvcf-v2"
+  private val wgsCramEsName = "wgs-cram-v2"
 
   /** Implicit summoner, for convenience. */
   def apply[Document: ElasticsearchIndex]: ElasticsearchIndex[Document] =
     implicitly[ElasticsearchIndex[Document]]
 
   implicit val WgsUbam: ElasticsearchIndex[DocumentWgsUbam] =
-    ElasticsearchIndex(ElasticsearchFieldMapper.NumericBooleanDateAndKeywordFields)
+    new ElasticsearchIndex[DocumentWgsUbam](
+      wgsUbamEsName,
+      ElasticsearchFieldMapper.NumericBooleanDateAndKeywordFields
+    )
 
   implicit val Gvcf: ElasticsearchIndex[DocumentGvcf] =
-    ElasticsearchIndex(ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords)
+    new ElasticsearchIndex[DocumentGvcf](
+      gvcfEsName,
+      ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
+    )
 
   implicit val WgsCram: ElasticsearchIndex[DocumentWgsCram] =
-    ElasticsearchIndex(ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords)
+    new ElasticsearchIndex[DocumentWgsCram](
+      wgsCramEsName,
+      ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
+    )
 }

--- a/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
+++ b/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
@@ -68,29 +68,25 @@ object ElasticsearchIndex extends Elastic4sAutoDerivation {
   lazy val dateTimeFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy/MM/dd")
 
-  private val wgsUbamEsName = "wgs-ubam"
-  private val gvcfEsName = "gvcf-v2"
-  private val wgsCramEsName = "wgs-cram-v2"
-
   /** Implicit summoner, for convenience. */
   def apply[Document: ElasticsearchIndex]: ElasticsearchIndex[Document] =
     implicitly[ElasticsearchIndex[Document]]
 
   implicit val WgsUbam: ElasticsearchIndex[DocumentWgsUbam] =
     new ElasticsearchIndex[DocumentWgsUbam](
-      wgsUbamEsName,
+      "wgs-ubam",
       ElasticsearchFieldMapper.NumericBooleanDateAndKeywordFields
     )
 
   implicit val Gvcf: ElasticsearchIndex[DocumentGvcf] =
     new ElasticsearchIndex[DocumentGvcf](
-      gvcfEsName,
+      "gvcf-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
 
   implicit val WgsCram: ElasticsearchIndex[DocumentWgsCram] =
     new ElasticsearchIndex[DocumentWgsCram](
-      wgsCramEsName,
+      "wgs-cram-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
 }

--- a/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
+++ b/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
@@ -79,14 +79,18 @@ object ElasticsearchIndex extends Elastic4sAutoDerivation {
     )
 
   implicit val Gvcf: ElasticsearchIndex[DocumentGvcf] =
-    // despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS
+    /* Despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS.
+     * Since we compute GCS paths from the ES index name, inconsistency would break GCS paths.
+     */
     new ElasticsearchIndex[DocumentGvcf](
       "gvcf-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
 
   implicit val WgsCram: ElasticsearchIndex[DocumentWgsCram] =
-    // despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS
+    /* Despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS.
+     * Since we compute GCS paths from the ES index name, inconsistency would break GCS paths.
+     */
     new ElasticsearchIndex[DocumentWgsCram](
       "wgs-cram-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords

--- a/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
+++ b/clio-dataaccess-model/src/main/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndex.scala
@@ -79,18 +79,16 @@ object ElasticsearchIndex extends Elastic4sAutoDerivation {
     )
 
   implicit val Gvcf: ElasticsearchIndex[DocumentGvcf] =
-    /* Despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS.
-     * Since we compute GCS paths from the ES index name, inconsistency would break GCS paths.
-     */
+    // Despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS.
+    // Since we compute GCS paths from the ES index name, inconsistency would break GCS paths.
     new ElasticsearchIndex[DocumentGvcf](
       "gvcf-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
 
   implicit val WgsCram: ElasticsearchIndex[DocumentWgsCram] =
-    /* Despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS.
-     * Since we compute GCS paths from the ES index name, inconsistency would break GCS paths.
-     */
+    // Despite being decoupled from "v1", we append -v2 to keep ES indices consistent with GCS.
+    // Since we compute GCS paths from the ES index name, inconsistency would break GCS paths.
     new ElasticsearchIndex[DocumentWgsCram](
       "wgs-cram-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords

--- a/clio-dataaccess-model/src/test/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/DocumentMock.scala
+++ b/clio-dataaccess-model/src/test/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/DocumentMock.scala
@@ -35,12 +35,14 @@ object DocumentMock extends Elastic4sAutoDerivation {
   )
 
   implicit val index: ElasticsearchIndex[DocumentMock] =
-    ElasticsearchIndex[DocumentMock](
+    new ElasticsearchIndex[DocumentMock](
+      "mock",
       ElasticsearchFieldMapper.NumericBooleanDateAndKeywordFields
     )
 
   val indexWithTextFields: ElasticsearchIndex[DocumentMock] =
-    ElasticsearchIndex[DocumentMock](
+    new ElasticsearchIndex[DocumentMock](
+      "mock",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
 }

--- a/clio-dataaccess-model/src/test/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndexSpec.scala
+++ b/clio-dataaccess-model/src/test/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndexSpec.scala
@@ -9,12 +9,14 @@ class ElasticsearchIndexSpec extends FlatSpec with Matchers with Elastic4sAutoDe
   import com.sksamuel.elastic4s.circe._
 
   it should behave like aV1Index(
-    ElasticsearchIndex[DocumentMock](
+    new ElasticsearchIndex[DocumentMock](
+      "mock",
       ElasticsearchFieldMapper.NumericBooleanDateAndKeywordFields
     )
   )
   it should behave like aV2Index(
-    ElasticsearchIndex[DocumentMock](
+    new ElasticsearchIndex[DocumentMock](
+      "mock_v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
   )

--- a/clio-dataaccess-model/src/test/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndexSpec.scala
+++ b/clio-dataaccess-model/src/test/scala/org/broadinstitute/clio/server/dataaccess/elasticsearch/ElasticsearchIndexSpec.scala
@@ -16,7 +16,7 @@ class ElasticsearchIndexSpec extends FlatSpec with Matchers with Elastic4sAutoDe
   )
   it should behave like aV2Index(
     new ElasticsearchIndex[DocumentMock](
-      "mock_v2",
+      "mock-v2",
       ElasticsearchFieldMapper.StringsToTextFieldsWithSubKeywords
     )
   )
@@ -54,7 +54,7 @@ class ElasticsearchIndexSpec extends FlatSpec with Matchers with Elastic4sAutoDe
 
   def aV2Index(index: ElasticsearchIndex[DocumentMock]): Unit = {
     it should "indexName for v2 document" in {
-      index.indexName should be("mock_v2")
+      index.indexName should be("mock-v2")
     }
 
     it should "indexType for v2 document" in {


### PR DESCRIPTION
…onsistency

### Description

Addresses ticket: [https://broadinstitute.atlassian.net/browse/DSDEGP-2014](url)
Note: hardcoded Elastic Search index names to use dashes instead of underscores. Consequently removed logic that converts underscores to dashes when deriving cloud storage root path from Elastic Search name. When merged, this change will trigger dev rebuild.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
