### PR TITLE
DSDEGP-2063 Fix partial recovery logic

### DIFF
--- a/clio-server/src/main/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAO.scala
+++ b/clio-server/src/main/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAO.scala
@@ -151,11 +151,7 @@ trait PersistenceDAO extends LazyLogging {
       val dayDirectoryOfLastUpsert = last.getParent.toString
       /*
        * Given the path in storage to the last upsert known to Elasticsearch, we want to keep
-       * only the day-directories for upserts following that upsert, to avoid pointlessly
-       * examining paths which are definitely already in Elasticsearch.
-       *
-       * We filter inclusively on date because the most recent document in Elasticsearch
-       * might not have been the last document upsert-ed during the day it was added.
+       * only the day-directory in which we find the upsert, and all following directories.
        */
       _.toString >= dayDirectoryOfLastUpsert
     }

--- a/clio-server/src/main/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAO.scala
+++ b/clio-server/src/main/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAO.scala
@@ -166,13 +166,13 @@ trait PersistenceDAO extends LazyLogging {
       _.toString <= pathOfLastUpsert
     }
 
-    getPathsOrderedBy(rootDir, pathOrdering, dayFilter)
     /*
-       * `dropWhile` instead of `filterNot` because we know `getPathsOrderedBy` is going
-       * to return paths in order by time, so once we see a document which is more recent
-       * than the latest known upsert, all following documents must also be more recent
-       * than that upsert.
-       */
+     * `dropWhile` instead of `filterNot` because we know `getPathsOrderedBy` is going
+     * to return paths in order by time, so once we see a document which is more recent
+     * than the latest known upsert, all following documents must also be more recent
+     * than that upsert.
+     */
+    getPathsOrderedBy(rootDir, pathOrdering, dayFilter)
       .dropWhile(docIsNotMoreRecentThanLastUpsert)
       .map { p =>
         decode[D](new String(Files.readAllBytes(p))).fold(throw _, identity)

--- a/clio-server/src/main/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAO.scala
+++ b/clio-server/src/main/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAO.scala
@@ -150,10 +150,9 @@ trait PersistenceDAO extends LazyLogging {
     val dayFilter = lastToIgnore.fold((_: Path) => true) { last =>
       val dayDirectoryOfLastUpsert = last.getParent.toString
       /*
-       * Given an existing path to a document which contains the last upsert known to
-       * Elasticsearch, we want to keep only the day-directories for upserts following
-       * that upsert, to avoid pointlessly examining upserts which are definitely already
-       * in Elasticsearch.
+       * Given the path in storage to the last upsert known to Elasticsearch, we want to keep
+       * only the day-directories for upserts following that upsert, to avoid pointlessly
+       * examining paths which are definitely already in Elasticsearch.
        *
        * We filter inclusively on date because the most recent document in Elasticsearch
        * might not have been the last document upsert-ed during the day it was added.

--- a/clio-server/src/test/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAOSpec.scala
+++ b/clio-server/src/test/scala/org/broadinstitute/clio/server/dataaccess/PersistenceDAOSpec.scala
@@ -73,7 +73,7 @@ class PersistenceDAOSpec
   }
 
   // From StackOverflow: https://stackoverflow.com/a/11458240
-  def cut[A](xs: Seq[A], n: Int): Vector[Seq[A]] = {
+  def cutIntoBuckets[A](xs: Seq[A], n: Int): Vector[Seq[A]] = {
     val m = xs.length
     val targets = (0 to n).map { x =>
       math.round((x.toDouble * m) / n).toInt
@@ -102,11 +102,11 @@ class PersistenceDAOSpec
       val now = OffsetDateTime.now()
 
       val days = Seq(now.minusYears(1L), now.minusMonths(1L), now.minusDays(1L), now)
-      val docsByDay = cut(documents, 4)
+      val docsByDay = days.zip(cutIntoBuckets(documents, days.size))
 
       for {
         _ <- dao.initialize(Seq(index))
-        _ = days.zip(docsByDay).foreach {
+        _ = docsByDay.foreach {
           case (day, docs) =>
             val dir = Files.createDirectories(
               dao.rootPath.resolve(


### PR DESCRIPTION
### Description

The bug was: during partial recovery, Clio would only recover upserts from the day of the last-known upsert. This was caused by a mismatched comparator in a filter used to decide which directories in GCS should be `ls`'d for upsert records.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
