### PR TITLE
Build and test cleanups / fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,8 +150,3 @@ lazy val `clio-integration-test` = project
   .disablePlugins(AssemblyPlugin)
   .settings(commonSettings)
   .settings(libraryDependencies ++= Dependencies.IntegrationTestDependencies)
-
-addCommandAlias(
-  "testCoverage",
-  "; clean; coverage; test; coverageOff; coverageReport; coverageAggregate"
-)

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ val commonSettings: Seq[Setting[_]] = Seq(
 
 val commonDockerSettings: Seq[Setting[_]] = Seq(
   assemblyJarName in assembly := Versioning.assemblyName.value,
+  test in assembly := {},
   imageNames in docker := Docker.imageNames.value,
   buildOptions in docker := Docker.buildOptions.value
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,3 @@
 # Set the sbt version used by the project. scala version set in build.sbt.
 # suppress inspection "UnusedProperty"
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/src/main/scala/org/broadinstitute/clio/integrationtest/ClioIntegrationTestSettings.scala
+++ b/project/src/main/scala/org/broadinstitute/clio/integrationtest/ClioIntegrationTestSettings.scala
@@ -40,19 +40,19 @@ object ClioIntegrationTestSettings extends BuildInfoKeys {
   private val TestcontainersPropsFile = "testcontainers.properties"
 
   /** Organization, name, and version for the "ambassador" image used by Testcontainers. */
-  private val AmbassadorImageId = "richnorth/ambassador:latest"
+  private val AmbassadorImageId = "alpine/socat:latest"
 
   /** Java property used to override the default ambassador image in Testcontainers. */
-  private val AmbassadorImageProp = "ambassador.container.image"
+  private val AmbassadorImageProp = "socat.container.image"
 
   /**
     * The output of `docker images` changed between version 1.X and version 17.X.
     *
     * In 1.X, images are prefixed with the repository name they came from, i.e.:
-    *   docker.io/richnorth/ambassador:latest
+    *   docker.io/alpine/socat:latest
     *
     * In 17.X, the prefix is gone:
-    *   richnorth/ambassador:latest
+    *   alpine/socat:latest
     *
     * Testcontainers-java can only handle the latter by default, but it exposes a
     * way to override its built-in image names via properties file. We override the


### PR DESCRIPTION
### Description

When we upgraded to the latest testcontainers-scala, it pulled in a new version of testcontainers-java, which has switched to a new "ambassador" image for exposing containers running within docker-compose. We need to update our integration-test-setup to match.

This also opportunistically turns off `test in assembly` by default, and bumps to the latest sbt 0.13.x.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
