### PR TITLE
Fix overwrite check when ES returns null for a field.

### DIFF
--- a/clio-server/src/main/scala/org/broadinstitute/clio/server/service/IndexService.scala
+++ b/clio-server/src/main/scala/org/broadinstitute/clio/server/service/IndexService.scala
@@ -140,9 +140,10 @@ abstract class IndexService[CI <: ClioIndex](
         Move - effectively an Add and Remove. This will not overwrite.
         Copy - effectively an Add. This will not overwrite.
      */
-    val replaceOperations: Seq[Replace] = differences.ops.flatMap {
-      case replace: Replace => Some(replace).filter(_.value != Json.Null)
-      case _                => None
+    val replaceOperations: Seq[Replace] = differences.ops.collect {
+      case replace @ Replace(_, value, existing)
+          if value != Json.Null && !existing.contains(Json.Null) =>
+        replace
     }
 
     if (replaceOperations.isEmpty) {

--- a/clio-server/src/test/scala/org/broadinstitute/clio/server/service/WgsCramServiceSpec.scala
+++ b/clio-server/src/test/scala/org/broadinstitute/clio/server/service/WgsCramServiceSpec.scala
@@ -54,7 +54,8 @@ class WgsCramServiceSpec extends IndexServiceSpec[WgsCramIndex.type]("WgsCramSer
         URI.create(s"gs://path/cramPath${WgsCramExtensions.CramExtension}")
       ),
       notes = Option("notable update"),
-      documentStatus = documentStatus
+      documentStatus = documentStatus,
+      workspaceName = Option("the workspace")
     )
   }
 


### PR DESCRIPTION
### Description

Caught by the integration tests [here](https://gotc-jenkins.dsp-techops.broadinstitute.org/job/clio-stage-RC/44/console). If ES returns `null` for a field instead of omitting the field (which it seems to do for booleans and numbers), the server will prevent overwriting the value.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
