### PR TITLE
DSDEGP-1985 Don't time out a request while processing its response.

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/webclient/ClioWebClient.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/webclient/ClioWebClient.scala
@@ -108,7 +108,7 @@ class ClioWebClient private[client] (
     retriedResponse.flatMapConcat { response =>
       if (response.status.isSuccess()) {
         logger.debug(s"Successfully completed request: $request")
-        response.entity.withoutSizeLimit().dataBytes
+        response.entity.withoutSizeLimit().dataBytes.idleTimeout(requestTimeout)
       } else {
         response.entity.dataBytes.reduce(_ ++ _).flatMapConcat { bytes =>
           Source.failed {

--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/webclient/ClioWebClient.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/webclient/ClioWebClient.scala
@@ -84,13 +84,13 @@ class ClioWebClient private[client] (
 
     /*
      * Reusable `Source` which will run the given `HttpRequest` over the connection
-     * flow to the Clio server, erroring out early if the request fails to complete
+     * flow to the Clio server, erroring out early if the response fails to arrive
      * within the request timeout.
      */
     val responseSource = Source
       .single(requestWithCreds)
       .via(connectionFlow)
-      .completionTimeout(requestTimeout)
+      .initialTimeout(requestTimeout)
 
     /*
      * Retry on any connection failures (since Akka's built-in retry mechanisms


### PR DESCRIPTION
### Description

In my test query of all-the-ubams, I saw the client hit a completion timeout after 30 seconds (our default response timeout) while in the midst of printing results. As far as I can tell, this is because Akka HTTP sets up its connection streams so that they don't complete until _after_ the entity stream of the HTTP response completes. Since the client was (correctly) still pulling from the response stream after 30 seconds, the HTTP connection failed to complete within 30 seconds, triggering our timeout.

This PR changes the timeout to be less strict. If the server fails to send any sort of response after 30 seconds, the client will still bail out, but once a response comes in the client will pull the response body for as long as it takes.

I tried to reproduce the weird stream-completion setup in a unit test with no success. I also tried to munge our LoadIntegrationSpec to simulate a query that takes longer than the request timeout to print, but lowering the timeout there caused the spec to fail during its mass-upload phase. I made [DSDEGP-2269](https://broadinstitute.atlassian.net/browse/DSDEGP-2269) to track fixing the upsert bottleneck.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
