### PR TITLE
Make ordering of paths-to-delete deterministic.

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeleteExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeleteExecutor.scala
@@ -139,7 +139,7 @@ class DeleteExecutor[CI <: ClioIndex](deleteCommand: DeleteCommand[CI])(
 
     val paths = metadata.pathsToDelete.to[immutable.Iterable]
     Source[URI](paths)
-      .mapAsyncUnordered(paths.size) { path =>
+      .mapAsync(paths.size) { path =>
         Future(path -> ioUtil.googleObjectExists(path))
       }
       .fold(Right(immutable.Seq.empty[URI]): Either[Seq[Throwable], immutable.Seq[URI]]) {


### PR DESCRIPTION
### Description

This should prevent spurious test failures.

Making scalamock ignore `Iterable` ordering is doable, but ugly. We don't actually rely on the map-async being unordered here because the next step in the stream is a `fold`, so we can't progress until all of the paths are checked anyways. We also set up the `mapAsync` with parallelism `paths + 1` so all the checks are guaranteed to launch at the same time.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
