### PR TITLE
DSDEGP-2090 Deliver idats to a subdirectory of the target path

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverArraysExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverArraysExecutor.scala
@@ -27,14 +27,15 @@ class DeliverArraysExecutor(deliverCommand: DeliverArrays)(implicit ec: Executio
   ): Source[(ArraysMetadata, immutable.Seq[IoOp]), NotUsed] = {
     (deliveredMetadata.grnIdatPath, deliveredMetadata.redIdatPath) match {
       case (Some(grn), Some(red)) => {
+        val idatDestination = deliverCommand.destination.resolve("/idat/")
         val movedGrnIdat = Metadata.findNewPathForMove(
           grn,
-          deliverCommand.destination,
+          idatDestination,
           ArraysExtensions.IdatExtension
         )
         val movedRedIdat = Metadata.findNewPathForMove(
           red,
-          deliverCommand.destination,
+          idatDestination,
           ArraysExtensions.IdatExtension
         )
         val idatCopies = immutable

--- a/clio-client/src/test/scala/org/broadinstitute/clio/client/dispatch/DeliverArraysExecutorSpec.scala
+++ b/clio-client/src/test/scala/org/broadinstitute/clio/client/dispatch/DeliverArraysExecutorSpec.scala
@@ -49,10 +49,18 @@ class DeliverArraysExecutorSpec extends BaseClientSpec with AsyncMockFactory {
     executor.buildMove(metadata, ioUtil).runWith(Sink.head).map {
       case (newMetadata, ops) =>
         val movedGrn = metadata.grnIdatPath.map(
-          Metadata.findNewPathForMove(_, destination, ArraysExtensions.IdatExtension)
+          Metadata.buildFilePath(
+            _,
+            destination.resolve(DeliverArraysExecutor.IdatsDir),
+            ArraysExtensions.IdatExtension
+          )
         )
         val movedRed = metadata.redIdatPath.map(
-          Metadata.findNewPathForMove(_, destination, ArraysExtensions.IdatExtension)
+          Metadata.buildFilePath(
+            _,
+            destination.resolve(DeliverArraysExecutor.IdatsDir),
+            ArraysExtensions.IdatExtension
+          )
         )
 
         val grnMove = metadata.grnIdatPath.zip(movedGrn).map {

--- a/clio-client/src/test/scala/org/broadinstitute/clio/client/dispatch/MoveExecutorSpec.scala
+++ b/clio-client/src/test/scala/org/broadinstitute/clio/client/dispatch/MoveExecutorSpec.scala
@@ -110,7 +110,7 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
           (ioUtil.isGoogleObject _).expects(uri).returning(true)
 
           val expectedDest =
-            Metadata.findNewPathForMove(uri, destination, ext, newBasename)
+            Metadata.buildFilePath(uri, destination, ext, newBasename)
           (ioUtil.copyGoogleObject _).expects(uri, expectedDest).returning(())
       }
       (ioUtil
@@ -206,7 +206,7 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
     val webClient = mock[ClioWebClient]
 
     val movedCram = metadata.cramPath.map(
-      Metadata.findNewPathForMove(_, destination, CramExtensions.CramExtension)
+      Metadata.buildFilePath(_, destination, CramExtensions.CramExtension)
     )
 
     (webClient
@@ -217,7 +217,7 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
     (ioUtil.isGoogleDirectory _).expects(destination).returning(true)
 
     val movedCrai = metadata.craiPath.map(
-      Metadata.findNewPathForMove(_, destination, CramExtensions.CraiExtension)
+      Metadata.buildFilePath(_, destination, CramExtensions.CraiExtension)
     )
     metadata.craiPath.zip(movedCrai).foreach {
       case (src, dest) =>
@@ -245,10 +245,10 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
     val webClient = mock[ClioWebClient]
 
     val movedCram = metadata.cramPath.map(
-      Metadata.findNewPathForMove(_, destination, CramExtensions.CramExtension)
+      Metadata.buildFilePath(_, destination, CramExtensions.CramExtension)
     )
     val movedCrai = metadata.craiPath.map(
-      Metadata.findNewPathForMove(_, destination, CramExtensions.CraiExtension)
+      Metadata.buildFilePath(_, destination, CramExtensions.CraiExtension)
     )
 
     (webClient
@@ -310,7 +310,7 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
         (ioUtil.isGoogleObject _).expects(uri).returning(true)
 
         val expectedDest =
-          Metadata.findNewPathForMove(uri, destination, ext)
+          Metadata.buildFilePath(uri, destination, ext)
         (ioUtil.copyGoogleObject _)
           .expects(uri, expectedDest)
           .throwing(new IOException(uri.toString))
@@ -341,7 +341,7 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
         (ioUtil.isGoogleObject _).expects(uri).returning(true)
 
         val expectedDest =
-          Metadata.findNewPathForMove(uri, destination, ext)
+          Metadata.buildFilePath(uri, destination, ext)
         (ioUtil.copyGoogleObject _).expects(uri, expectedDest).returning(())
     }
 
@@ -375,7 +375,7 @@ class MoveExecutorSpec extends BaseClientSpec with AsyncMockFactory {
         (ioUtil.isGoogleObject _).expects(uri).returning(true)
 
         val expectedDest =
-          Metadata.findNewPathForMove(uri, destination, ext)
+          Metadata.buildFilePath(uri, destination, ext)
         (ioUtil.copyGoogleObject _).expects(uri, expectedDest).returning(())
     }
     (ioUtil

--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/ArraysTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/ArraysTests.scala
@@ -413,8 +413,8 @@ trait ArraysTests { self: BaseIntegrationSpec =>
     val rootSource = rootTestStorageDir / s"arrays/$chipwellBarcode/v$version/"
     val vcfSource = rootSource / vcfName
     val vcfIndexSource = rootSource / vcfIndexName
-    val grnIdatSource = rootSource / grnIdatName
-    val redIdatSource = rootSource / redIdatName
+    val grnIdatSource = rootSource / "idats" / grnIdatName
+    val redIdatSource = rootSource / "idats" / redIdatName
 
     val key = ArraysKey(Location.GCP, Symbol(chipwellBarcode), 1)
     val metadata = ArraysMetadata(
@@ -820,8 +820,8 @@ trait ArraysTests { self: BaseIntegrationSpec =>
     val vcfDestination = rootDestination / s"$prefix$vcfName"
     val vcfIndexDestination = rootDestination / s"$prefix$vcfIndexName"
     val gtcDestination = rootDestination / s"$prefix$gtcName"
-    val grnIdatDestination = rootDestination / grnIdatName
-    val redIdatDestination = rootDestination / redIdatName
+    val grnIdatDestination = rootDestination / "idats" / grnIdatName
+    val redIdatDestination = rootDestination / "idats" / redIdatName
 
     val key = ArraysKey(Location.GCP, Symbol(barcode), version)
     val metadata = ArraysMetadata(
@@ -938,8 +938,8 @@ trait ArraysTests { self: BaseIntegrationSpec =>
     val rootSource = rootTestStorageDir / s"arrays/$barcode/v$version/"
     val vcfSource = rootSource / vcfName
     val vcfIndexSource = rootSource / vcfIndexName
-    val grnIdatSource = rootSource / grnIdatName
-    val redIdatSource = rootSource / redIdatName
+    val grnIdatSource = rootSource / "idats" / grnIdatName
+    val redIdatSource = rootSource / "idats" / redIdatName
 
     val key = ArraysKey(Location.GCP, Symbol(barcode), version)
     val metadata = ArraysMetadata(

--- a/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/Metadata.scala
+++ b/clio-transfer-model/src/main/scala/org/broadinstitute/clio/transfer/model/Metadata.scala
@@ -48,7 +48,7 @@ trait Metadata[M <: Metadata[M]] { self: M =>
 
     mapMove {
       case (pathOpt, ext) =>
-        pathOpt.map(Metadata.findNewPathForMove(_, destination, ext, newBasename))
+        pathOpt.map(Metadata.buildFilePath(_, destination, ext, newBasename))
     }
   }
 
@@ -106,13 +106,12 @@ object Metadata {
     * extension. Rather than make dangerous guesses, we require that the code calling
     * the move operation provide the file extension to retain during the move operation.
     */
-  def findNewPathForMove(
+  def buildFilePath(
     source: URI,
     destination: URI,
     extension: String,
     newBasename: Option[String] = None
   ): URI = {
-    // TODO: Rewrite this using a Path-based API.
     val srcName = new File(source.getPath).getName
     val srcBase = srcName.take(srcName.toLowerCase.lastIndexOf(extension))
     destination.resolve(s"${newBasename.getOrElse(srcBase)}$extension")


### PR DESCRIPTION
### Description

Needed to match the expectations from the picard-private tool which generates the samples.tsv file.

Raises the question (for later): if the clio-client knows that idats should go in a sub-directory, should it also know that all delivered files go in a directory tree for the project / sample / barcode / version? It'd save us an extra query in the wdl.

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
