### PR TITLE
When running clio-client commands as part of an interation test, don't show the client output.

### DIFF
--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/BaseIntegrationSpec.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/BaseIntegrationSpec.scala
@@ -193,7 +193,7 @@ abstract class BaseIntegrationSpec(clioDescription: String)
     args: String*
   ): Future[Out] = {
     clioClient
-      .instanceMain((command +: args).toArray)
+      .instanceMain((command +: args).toArray, _ => ())
       .fold(
         earlyReturn =>
           Future


### PR DESCRIPTION
Our integration tests produce > 30MB of output when running. It looks like most of that output is just the output of running the clio-client commands that the tests use. This change prevents this output from being generated.
 
- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
