### PR TITLE
DSDEGP-2829: back out new metrics delivery feature

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/metadata/CramDeliverer.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/metadata/CramDeliverer.scala
@@ -37,7 +37,9 @@ class CramDeliverer extends MetadataMover[CramMetadata] {
       writeMd5Op.toIterable
     ).flatten
 
-    if (src.regulatoryDesignation.exists(_.equals(RegulatoryDesignation.ResearchOnly))) {
+    if (false && src.regulatoryDesignation.exists(
+          _.equals(RegulatoryDesignation.ResearchOnly)
+        )) {
       lazy val oldBaseName =
         src.cramPath.map(
           p => File(p.getPath).name.replace(CramExtensions.CramExtension, "")

--- a/clio-client/src/test/scala/org/broadinstitute/clio/client/metadata/CramDelivererSpec.scala
+++ b/clio-client/src/test/scala/org/broadinstitute/clio/client/metadata/CramDelivererSpec.scala
@@ -5,8 +5,9 @@ import java.net.URI
 import org.broadinstitute.clio.client.dispatch.MoveExecutor.{MoveOp, WriteOp}
 import org.broadinstitute.clio.transfer.model.cram.{CramExtensions, CramMetadata}
 import org.broadinstitute.clio.util.model.RegulatoryDesignation
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Ignore, Matchers}
 
+@Ignore
 class CramDelivererSpec extends FlatSpec with Matchers {
   behavior of "CramDeliverer"
 


### PR DESCRIPTION
This disables the code and tests associated with the new metrics file delivery feature. Since there isn't currently a test of delivery without the metrics files, all whole genome delivery tests are disabled by this change.

This is a do not merge PR as the change will be deployed as a hotfix. A later PR will fix the issue on `develop`.

https://broadinstitute.atlassian.net/browse/DSDEGP-2829
----

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [x] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
