### PR TITLE
DSDEGP-2890: Deliver when workspaceName in Arrays metadata is empty.

### DIFF
--- a/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverExecutor.scala
+++ b/clio-client/src/main/scala/org/broadinstitute/clio/client/dispatch/DeliverExecutor.scala
@@ -32,7 +32,7 @@ class DeliverExecutor[CI <: DeliverableIndex](
 
     baseStream.flatMapConcat { metadata =>
       metadata.workspaceName
-        .filterNot(n => deliverCommand.force || n == newWorkspace)
+        .filterNot(n => deliverCommand.force || n.isEmpty || n == newWorkspace)
         .fold(Source.single(metadata)) { existingWorkspace =>
           Source.failed(
             new UnsupportedOperationException(


### PR DESCRIPTION
### Description
https://broadinstitute.atlassian.net/browse/DSDEGP-2890

Undelivery leaves an empty workspaceName field in Arrays metadata.
This change allows delivery when workspaceName is empty ('') in the current metadata.
The presence of any workspaceName field used to prevent delivery without a --force option.
----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
