### PR TITLE
Fix regulatory designation test to work in dev database by filtering based on test project.

### DIFF
--- a/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/CramTests.scala
+++ b/clio-integration-test/src/it/scala/org/broadinstitute/clio/integrationtest/tests/CramTests.scala
@@ -253,7 +253,9 @@ trait CramTests { self: BaseIntegrationSpec =>
       results <- runCollectJson(
         ClioCommand.queryCramName,
         "--regulatory-designation",
-        RegulatoryDesignation.ClinicalDiagnostics.entryName
+        RegulatoryDesignation.ClinicalDiagnostics.entryName,
+        "--project",
+        project
       )
     } yield {
       results should have length 3


### PR DESCRIPTION
### Description

The new regulatory designation test works fine when run in isolation but doesn't work correctly when run against the dev database. Changing the query to filter based on the test project should fix this problem.

Integration test build here: https://gotc-jenkins.dsp-techops.broadinstitute.org/job/clio-integration/934

----

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
