### PR TITLE
GH-595: Update AkkaVersion to 2.5.20 to avoid TTL warning in response.

### DIFF
--- a/project/src/main/scala/org/broadinstitute/clio/sbt/Dependencies.scala
+++ b/project/src/main/scala/org/broadinstitute/clio/sbt/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   // The version numbers of each main and test dependency.
   private val AkkaHttpCirceVersion = "1.21.0"
   private val AkkaHttpVersion = "10.1.8"
-  private val AkkaVersion = "2.5.19"
+  private val AkkaVersion = "2.5.20"
   private val AlpakkaVersion = "0.20"
   private val ApacheHttpClientVersion = "4.5.6"
   private val BetterFilesVersion = "3.6.0"


### PR DESCRIPTION
That is all.