### PR TITLE
GH-597: Back off to version 2.5.16 to work around empty JSON bug.

### DIFF
--- a/project/src/main/scala/org/broadinstitute/clio/sbt/Dependencies.scala
+++ b/project/src/main/scala/org/broadinstitute/clio/sbt/Dependencies.scala
@@ -8,7 +8,7 @@ import sbt._
 object Dependencies {
   // The version numbers of each main and test dependency.
   private val AkkaHttpCirceVersion = "1.21.0"
-  private val AkkaHttpVersion = "10.1.8"
+  private val AkkaHttpVersion = "10.1.5"
   private val AkkaVersion = "2.5.16"
   private val AlpakkaVersion = "0.20"
   private val ApacheHttpClientVersion = "4.5.6"

--- a/project/src/main/scala/org/broadinstitute/clio/sbt/Dependencies.scala
+++ b/project/src/main/scala/org/broadinstitute/clio/sbt/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   // The version numbers of each main and test dependency.
   private val AkkaHttpCirceVersion = "1.21.0"
   private val AkkaHttpVersion = "10.1.8"
-  private val AkkaVersion = "2.5.20"
+  private val AkkaVersion = "2.5.16"
   private val AlpakkaVersion = "0.20"
   private val ApacheHttpClientVersion = "4.5.6"
   private val BetterFilesVersion = "3.6.0"


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/GH-597

This should unblock our automated tests until I can get things working on a more recent version.