### PR TITLE
The download link for jprofiler changed

### DIFF
--- a/project/src/main/scala/org/broadinstitute/clio/sbt/Docker.scala
+++ b/project/src/main/scala/org/broadinstitute/clio/sbt/Docker.scala
@@ -41,7 +41,7 @@ object Docker {
 
       // Run this first so it's more likely to cache, since we won't be changing the version that often.
       runRaw(
-        s"wget -q https://download-keycdn.ej-technologies.com/jprofiler/$JProfilerVersion.tar.gz -P /tmp/ && " +
+        s"wget -q https://download-gcdn.ej-technologies.com/jprofiler/$JProfilerVersion.tar.gz -P /tmp/ && " +
           s"tar -xzf /tmp/$JProfilerVersion.tar.gz -C /usr/local &&" +
           s" rm /tmp/$JProfilerVersion.tar.gz"
       )


### PR DESCRIPTION
### Description

Our docker image includes jprofiler, and we download it using a URL that points to the CDN server for ej-technologies. Their CDN server changed names, and our docker build now fails. I've tested a build using this new name while building directly on a jenkins slave; it's hard to trigger it from a branch as the jenkins job uses `develop` to identify the branch to do docker push on.

### Checklist

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: Ensure that you have added or updated tests
- [ ] **Submitter**: If you're adding/switching libraries or otherwise changing the design, update the [design documentation](https://broadinstitute.atlassian.net/wiki/pages/viewpage.action?pageId=114531509).
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
* Review cycle:
  * Team may comment on PR at will
  * **Reviewer assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to reviewer** for further feedback
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Move the JIRA issue to QA once this checklist is completed
